### PR TITLE
Python jamf issues

### DIFF
--- a/.github/workflows/autopkg.yml
+++ b/.github/workflows/autopkg.yml
@@ -44,9 +44,7 @@ jobs:
     - name: python-jamf install
       run: |
         pip3 install -r requirements.txt
-        pip3 show python-jamf
-        which conf-python-jamf
-        head /usr/local/bin/conf-python-jamf
+        ls -lah  /usr/local/bin/
 
 
     - name:  AutoPkg Configuration

--- a/.github/workflows/autopkg.yml
+++ b/.github/workflows/autopkg.yml
@@ -34,18 +34,11 @@ jobs:
     - name: coreutils install
       run: |
         brew install coreutils
-        which -a python3
-        which -a python
-        which -a pip
-        which -a pip3
-        echo $PATH
 
 
     - name: python-jamf install
       run: |
         pip3 install -r requirements.txt
-        python3 --version | tr -d "Python "
-        ls -alh /Library/Frameworks/Python.framework/Versions/
 
     - name:  AutoPkg Configuration
       run: |
@@ -67,9 +60,10 @@ jobs:
         git config --global user.email "runner@githubactions.local"
         git config --global credential.helper store
         echo "https://${{ secrets.AUTOPKG_GITHUB_USER }}:${{ secrets.AUTOPKG_GITHUB_TOKEN }}@github.com" > ~/.git-credentials
+
     - name: Configure python-jamf
       run: |
-        conf-python-jamf --hostname "${{ secrets.JSS_URL }}" --user "${{ secrets.JSS_API_USERNAME }}" --passwd "${{ secrets.JSS_API_PASSWORD }}"
+        /Library/Frameworks/Python.framework/Versions/current/bin/conf-python-jamf --hostname "${{ secrets.JSS_URL }}" --user "${{ secrets.JSS_API_USERNAME }}" --passwd "${{ secrets.JSS_API_PASSWORD }}"
 
     - name: Setup SSH
       run: |

--- a/.github/workflows/autopkg.yml
+++ b/.github/workflows/autopkg.yml
@@ -44,8 +44,9 @@ jobs:
     - name: python-jamf install
       run: |
         pip3 install -r requirements.txt
-        find /usr/local /usr/opt -iname conf-python-jamf
+        find / -iname conf-python-jamf 2>/dev/null || return 0
         echo "Monkey"
+        ls -lah /Volumes
 
 
     - name:  AutoPkg Configuration

--- a/.github/workflows/autopkg.yml
+++ b/.github/workflows/autopkg.yml
@@ -44,7 +44,7 @@ jobs:
     - name: python-jamf install
       run: |
         pip3 install -r requirements.txt
-        ls -lah  /usr/local/bin/
+        find /usr -iname conf-python-jamf
 
 
     - name:  AutoPkg Configuration

--- a/.github/workflows/autopkg.yml
+++ b/.github/workflows/autopkg.yml
@@ -25,22 +25,23 @@ jobs:
       run: |
         curl -L https://github.com/autopkg/autopkg/releases/download/v2.4.1/autopkg-2.4.1.pkg --output /tmp/autopkg.pkg
         sudo installer -pkg /tmp/autopkg.pkg -target /
-        
-    - name: JSS importer install  
+
+    - name: JSS importer install
       run: |
         curl -L https://github.com/jssimporter/JSSImporter/releases/download/v1.1.6/jssimporter-1.1.6.pkg --output /tmp/jssimporter.pkg
         sudo installer -pkg /tmp/jssimporter.pkg -target /
 
-    - name: coreutils install  
-      run: |   
+    - name: coreutils install
+      run: |
         brew install coreutils
 
-    - name: python-jamf install  
-      run: |  
+    - name: python-jamf install
+      run: |
         pip3 install -r requirements.txt
         ls -lah ~
+        head `which conf-python-jamf`
 
-                        
+
     - name:  AutoPkg Configuration
       run: |
         defaults write com.github.autopkg RECIPE_OVERRIDE_DIRS "$(pwd)"/overrides/
@@ -54,7 +55,7 @@ jobs:
         /usr/libexec/PlistBuddy -c "Add :JSS_REPOS array" ~/Library/Preferences/com.github.autopkg.plist
         /usr/libexec/PlistBuddy -c "Add :JSS_REPOS:0 dict" ~/Library/Preferences/com.github.autopkg.plist
         /usr/libexec/PlistBuddy -c "Add :JSS_REPOS:0:type string CDP" ~/Library/Preferences/com.github.autopkg.plist
-      
+
     - name: Configure Git
       run: |
         git config --global user.name "runner"
@@ -64,7 +65,7 @@ jobs:
     - name: Configure python-jamf
       run: |
         conf-python-jamf --hostname "${{ secrets.JSS_URL }}" --user "${{ secrets.JSS_API_USERNAME }}" --passwd "${{ secrets.JSS_API_PASSWORD }}"
-        
+
     - name: Setup SSH
       run: |
         eval $(ssh-agent)
@@ -95,7 +96,7 @@ jobs:
 
     - name: Add AutoPkg repos
       run: |
-        for repo in $(cat repo_list.txt); do autopkg repo-add "$repo" && autopkg repo-update "$repo"; done    
+        for repo in $(cat repo_list.txt); do autopkg repo-add "$repo" && autopkg repo-update "$repo"; done
 
     - name: Checkout autopkg cache repo
       uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b
@@ -105,7 +106,7 @@ jobs:
         fetch-depth: 1
         ref: refs/heads/main
         path: cache
-        
+
     - name: Checkout your autopkg override repo
       uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b
       with:
@@ -114,7 +115,7 @@ jobs:
         fetch-depth: 1
         ref: refs/heads/main
         path: overrides
-        
+
 
     - name: Run AutoPkg
       run: |

--- a/.github/workflows/autopkg.yml
+++ b/.github/workflows/autopkg.yml
@@ -45,7 +45,6 @@ jobs:
       run: |
         pip3 install -r requirements.txt
         pip3 show python-jamf
-        pip3 inspect
         which conf-python-jamf
         head /usr/local/bin/conf-python-jamf
 

--- a/.github/workflows/autopkg.yml
+++ b/.github/workflows/autopkg.yml
@@ -38,8 +38,8 @@ jobs:
     - name: python-jamf install
       run: |
         pip3 install -r requirements.txt
-        ls -lah ~
-        head `which conf-python-jamf`
+        which conf-python-jamf
+        head /usr/local/bin/conf-python-jamf
 
 
     - name:  AutoPkg Configuration

--- a/.github/workflows/autopkg.yml
+++ b/.github/workflows/autopkg.yml
@@ -44,10 +44,8 @@ jobs:
     - name: python-jamf install
       run: |
         pip3 install -r requirements.txt
-        find / -iname conf-python-jamf 2>/dev/null || return 0
-        echo "Monkey"
-        ls -lah /Volumes
-
+        python3 --version | tr -d "Python "
+        ls -alh /Library/Frameworks/Python.framework/Versions/
 
     - name:  AutoPkg Configuration
       run: |

--- a/.github/workflows/autopkg.yml
+++ b/.github/workflows/autopkg.yml
@@ -44,7 +44,8 @@ jobs:
     - name: python-jamf install
       run: |
         pip3 install -r requirements.txt
-        find /usr -iname conf-python-jamf
+        find /usr -iname conf-python-jamf 2>/dev/null
+        echo "Monkey"
 
 
     - name:  AutoPkg Configuration

--- a/.github/workflows/autopkg.yml
+++ b/.github/workflows/autopkg.yml
@@ -44,7 +44,7 @@ jobs:
     - name: python-jamf install
       run: |
         pip3 install -r requirements.txt
-        find /usr -iname conf-python-jamf 2>/dev/null
+        find /usr/local /usr/opt -iname conf-python-jamf
         echo "Monkey"
 
 

--- a/.github/workflows/autopkg.yml
+++ b/.github/workflows/autopkg.yml
@@ -34,10 +34,18 @@ jobs:
     - name: coreutils install
       run: |
         brew install coreutils
+        which -a python3
+        which -a python
+        which -a pip
+        which -a pip3
+        echo $PATH
+
 
     - name: python-jamf install
       run: |
         pip3 install -r requirements.txt
+        pip3 show python-jamf
+        pip3 inspect
         which conf-python-jamf
         head /usr/local/bin/conf-python-jamf
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 ###### Requirements without Version Specifiers ######
 requests
+python-jamf
 
 ###### Requirements with Version Specifiers ######
 #python-jamf == 0.8.2             # Version Matching. Must be version 0.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@
 requests
 
 ###### Requirements with Version Specifiers ######
-python-jamf == 0.8.2             # Version Matching. Must be version 0.8.2
+#python-jamf == 0.8.2             # Version Matching. Must be version 0.8.2


### PR DESCRIPTION
pip3 installed files are not being linked into /usr/local/bin and /Library/Frameworks/Python.framework/Versions/current/bin isn't in the path. Fixed issue by calling the full path /Library/Frameworks/Python.framework/Versions/current/bin/conf-python-jamf